### PR TITLE
Auto-update stats when pasting text

### DIFF
--- a/projects/token-visualizer/app.js
+++ b/projects/token-visualizer/app.js
@@ -446,7 +446,15 @@ async function init() {
   });
   unitRadios.forEach(r => r.addEventListener('change', updateAll));
   charsPerPageInput.addEventListener('change', updateAll);
-  pastedText.addEventListener('input', () => { updatePastedStats(getModelByValue(modelSelect.value) || MODELS[0]); if (usePasted.checked) updateAll(); });
+  pastedText.addEventListener('input', () => {
+    const hasText = (pastedText.value || '').length > 0;
+    if (hasText && !usePasted.checked) {
+      usePasted.checked = true;
+    } else if (!hasText && usePasted.checked) {
+      usePasted.checked = false;
+    }
+    updateAll();
+  });
   usePasted.addEventListener('change', updateAll);
 
   updateAll();


### PR DESCRIPTION
## Summary
- automatically toggle the "Use pasted text" option whenever the paste textbox gains or loses content
- trigger a full stats refresh on every change so token, character, page, and book calculations update immediately

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1e1a691083228910a65170e8696d)